### PR TITLE
Patch for Asterinas coverage

### DIFF
--- a/minicov/build.rs
+++ b/minicov/build.rs
@@ -17,8 +17,6 @@ fn main() {
         "c/InstrProfilingInternal.c",
         "c/InstrProfilingMerge.c",
         "c/InstrProfilingPlatformLinux.c",
-        "c/InstrProfilingPlatformOther.c",
-        "c/InstrProfilingPlatformWindows.c",
         "c/InstrProfilingWriter.c",
         "c/InstrProfilingValue.c",
         "c/InstrProfilingVersionVar.c",

--- a/minicov/c/InstrProfilingPlatformLinux.c
+++ b/minicov/c/InstrProfilingPlatformLinux.c
@@ -6,10 +6,6 @@
 |*
 \*===----------------------------------------------------------------------===*/
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__) || \
-    (defined(__sun__) && defined(__svr4__)) || defined(__NetBSD__) || \
-    defined(_AIX)
-
 #include "InstrProfiling.h"
 #include "InstrProfilingInternal.h"
 
@@ -225,6 +221,4 @@ COMPILER_RT_VISIBILITY int __llvm_write_binary_ids(ProfDataWriter *Writer) {
   (void)Writer;
   return 0;
 }
-#endif
-
 #endif


### PR DESCRIPTION
Patch added for collecting coverage data in Asterinas:
- forces minicov to compile the "Linux" platform, because it originally detected and compiled the "Other" platform, which did not match that of the LLVM generated instrumentations.